### PR TITLE
EPIC-1: DB schema & migrations (SQLite)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,37 @@
-    .PHONY: init dev run-bot lint fmt test doctor dirs
+.PHONY: init dev run-bot lint fmt test doctor dirs migrate seed clean-db
 
-    PY=poetry run
+PY=poetry run
+DEV_DIRS=var var/materials var/submissions var/exports var/tmp var/logs
 
-    DEV_DIRS=var var/materials var/submissions var/exports var/tmp var/logs
-
-    init: dirs
+init: dirs
 	poetry install
 
-    dev: init
+dev: init
 	@echo "Dev env ready"
 
-    run-bot:
+run-bot:
 	$(PY) python -m app.bot.main
 
-    lint:
+lint:
 	poetry run flake8 app
 
-    fmt:
+fmt:
 	poetry run black app tests && poetry run isort app tests
 
-    test:
+test:
 	$(PY) pytest -q
 
-    doctor:
+doctor:
 	bash scripts/doctor.sh
 
-    dirs:
+dirs:
 	@mkdir -p $(DEV_DIRS)
+
+migrate:
+	$(PY) python scripts/migrate.py
+
+seed:
+	SEED_OWNER_TG_ID=dev_owner $(PY) python scripts/seed.py
+
+clean-db:
+	rm -f var/app.db var/app.db-shm var/app.db-wal

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ make run-bot
 - `make lint` — линтеры
 - `make test` — тесты
 - `make run-bot` — запустить бота
+
+## Миграции и начальные данные
+
+```bash
+make migrate
+make seed
+sqlite3 var/app.db ".tables"
+sqlite3 var/app.db "SELECT id, role, tg_id FROM users;"

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,135 @@
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  tg_id            TEXT UNIQUE,
+  role             TEXT NOT NULL CHECK(role IN ('owner','teacher','student')),
+  name             TEXT,
+  created_at_utc   INTEGER NOT NULL,
+  updated_at_utc   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+
+CREATE TABLE IF NOT EXISTS weeks (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  week_no          INTEGER UNIQUE NOT NULL,
+  title            TEXT,
+  created_at_utc   INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS assignments (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  code             TEXT UNIQUE,
+  title            TEXT NOT NULL,
+  week_no          INTEGER,
+  deadline_ts_utc  INTEGER,
+  created_at_utc   INTEGER NOT NULL,
+  FOREIGN KEY (week_no) REFERENCES weeks(week_no) ON UPDATE CASCADE ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS slots (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  starts_at_utc    INTEGER NOT NULL,
+  duration_min     INTEGER NOT NULL,
+  capacity         INTEGER NOT NULL,
+  status           TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open','closed','canceled')),
+  created_by       INTEGER NOT NULL,
+  created_at_utc   INTEGER NOT NULL,
+  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS idx_slots_starts ON slots(starts_at_utc);
+
+CREATE TABLE IF NOT EXISTS slot_enrollments (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  slot_id          INTEGER NOT NULL,
+  user_id          INTEGER NOT NULL,
+  status           TEXT NOT NULL DEFAULT 'booked' CHECK(status IN ('booked','canceled','attended','no_show')),
+  booked_at_utc    INTEGER NOT NULL,
+  UNIQUE(slot_id, user_id),
+  FOREIGN KEY (slot_id) REFERENCES slots(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS materials (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  assignment_id    INTEGER,
+  path             TEXT NOT NULL,
+  sha256           TEXT NOT NULL,
+  size_bytes       INTEGER NOT NULL,
+  mime             TEXT,
+  uploaded_by      INTEGER NOT NULL,
+  created_at_utc   INTEGER NOT NULL,
+  FOREIGN KEY (assignment_id) REFERENCES assignments(id) ON DELETE SET NULL,
+  FOREIGN KEY (uploaded_by)  REFERENCES users(id)       ON DELETE RESTRICT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_materials_hash ON materials(sha256, size_bytes);
+CREATE INDEX IF NOT EXISTS idx_materials_assignment ON materials(assignment_id);
+
+CREATE TABLE IF NOT EXISTS submissions (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  assignment_id    INTEGER NOT NULL,
+  student_id       INTEGER NOT NULL,
+  path             TEXT NOT NULL,
+  sha256           TEXT NOT NULL,
+  size_bytes       INTEGER NOT NULL,
+  submitted_at_utc INTEGER NOT NULL,
+  FOREIGN KEY (assignment_id) REFERENCES assignments(id) ON DELETE CASCADE,
+  FOREIGN KEY (student_id)   REFERENCES users(id)       ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_subm_assignment ON submissions(assignment_id);
+CREATE INDEX IF NOT EXISTS idx_subm_student    ON submissions(student_id);
+
+CREATE TABLE IF NOT EXISTS grades (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  assignment_id    INTEGER NOT NULL,
+  student_id       INTEGER NOT NULL,
+  grader_id        INTEGER NOT NULL,
+  grade_value      TEXT,
+  comment          TEXT,
+  graded_at_utc    INTEGER NOT NULL,
+  UNIQUE(assignment_id, student_id),
+  FOREIGN KEY (assignment_id) REFERENCES assignments(id) ON DELETE CASCADE,
+  FOREIGN KEY (student_id)   REFERENCES users(id)       ON DELETE CASCADE,
+  FOREIGN KEY (grader_id)    REFERENCES users(id)       ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_utc           INTEGER NOT NULL,
+  request_id       TEXT,
+  actor_id         INTEGER,
+  as_user_id       INTEGER,
+  as_role          TEXT,
+  event            TEXT NOT NULL,
+  object_type      TEXT,
+  object_id        INTEGER,
+  meta_json        TEXT,
+  FOREIGN KEY (actor_id)   REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (as_user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_event_ts ON audit_log(event, ts_utc);
+
+CREATE TABLE IF NOT EXISTS state_store (
+  key              TEXT PRIMARY KEY,
+  role             TEXT,
+  value_json       TEXT NOT NULL,
+  created_at_utc   INTEGER NOT NULL,
+  expires_at_utc   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_state_expiry ON state_store(expires_at_utc);
+
+CREATE TABLE IF NOT EXISTS file_index (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  sha256           TEXT NOT NULL,
+  size_bytes       INTEGER NOT NULL,
+  refcount         INTEGER NOT NULL DEFAULT 1,
+  UNIQUE(sha256, size_bytes)
+);
+
+CREATE TABLE IF NOT EXISTS system_backups (
+  id               INTEGER PRIMARY KEY CHECK (id = 1),
+  last_full_ts_utc INTEGER,
+  last_inc_ts_utc  INTEGER,
+  updated_at_utc   INTEGER
+);
+INSERT OR IGNORE INTO system_backups(id) VALUES(1);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ pre-commit = "^3.8.0"
 [build-system]
 requires = ["poetry-core>=1.9.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.flake8]
+max-line-length = 120

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -26,4 +26,7 @@ df -h . | tail -n +2
 echo "[doctor] checking pre-commit"
 poetry run pre-commit --version || echo "pre-commit is not available (will be installed by poetry)"
 
+echo "[doctor] sqlite3 version"
+sqlite3 --version || echo "sqlite3 not found (optional for manual inspection)"
+
 echo "[doctor] done"

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import sqlite3
+import sys
+from pathlib import Path
+
+DB = Path("./var/app.db")
+MIGRATIONS_DIR = Path("./migrations")
+
+
+def main():
+    DB.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB)
+    conn.execute("PRAGMA foreign_keys=ON;")
+    conn.execute("CREATE TABLE IF NOT EXISTS __migrations__(name TEXT PRIMARY KEY)")
+    applied = {row[0] for row in conn.execute("SELECT name FROM __migrations__")}
+
+    for sql in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        if sql.name in applied:
+            continue
+        print(f"[migrate] applying {sql.name}")
+        conn.executescript(sql.read_text(encoding="utf-8"))
+        conn.execute("INSERT INTO __migrations__(name) VALUES (?)", (sql.name,))
+        conn.commit()
+
+    conn.close()
+    print("[migrate] done")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+DB = Path("./var/app.db")
+
+
+def now():
+    return int(time.time())
+
+
+def main():
+    tg_owner = os.getenv("SEED_OWNER_TG_ID", "owner_dev")
+    conn = sqlite3.connect(DB)
+    conn.execute("PRAGMA foreign_keys=ON;")
+
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO users(tg_id, role, name, created_at_utc, updated_at_utc)
+        VALUES(?, 'owner', 'Owner Dev', ?, ?)
+    """,
+        (tg_owner, now(), now()),
+    )
+
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO weeks(week_no, title, created_at_utc)
+        VALUES(1, 'Week 1', ?)
+    """,
+        (now(),),
+    )
+
+    conn.commit()
+    conn.close()
+    print("[seed] done")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,2 +1,16 @@
 def test_truth():
     assert True
+
+
+def test_migrate_creates_tables():
+    import pathlib
+    import sqlite3
+    import subprocess
+
+    db = pathlib.Path("var/app.db")
+    subprocess.run(["python", "scripts/migrate.py"], check=True)
+    conn = sqlite3.connect(db)
+    tables = {
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "users" in tables


### PR DESCRIPTION
### EPIC-1: DB schema & migrations

- Добавлены базовые таблицы (`users`, `assignments`, `weeks`, `slots`, `materials`, `submissions`, `grades`, `audit_log`, `state_store`, `file_index`, `system_backups`).
- Реализован простой раннер миграций (`scripts/migrate.py`) + цель `make migrate`.
- Добавлен сидер (`scripts/seed.py`) + цель `make seed` (создаётся dev-owner и Week 1).
- Обновлён `Makefile` и README (раздел о миграциях).
- Smoke-тест проверяет успешное создание таблицы `users`.

✅ Проверено локально: `make migrate` / `make seed` отрабатывают, таблицы и начальные данные создаются.

---

➡️ Далее переходим к **EPIC-2: StateStore + Callback codec** — реализация FSM-хранилища с TTL и валидацией.
