### PR TITLE
EPIC-2: StateStore & Callback codec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,7 @@ seed:
 
 clean-db:
 	rm -f var/app.db var/app.db-shm var/app.db-wal
+
+.PHONY: state-clean
+state-clean:
+	$(PY) python scripts/cleanup_state.py

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ make run-bot
 - `make fmt` — форматирование
 - `make lint` — линтеры
 - `make test` — тесты
-- `make run-bot` — запустить бота
+- `make state-clean` — очистить протухшие состояния (EPIC-2)
 
 ## Миграции и начальные данные
 
@@ -24,3 +24,10 @@ make migrate
 make seed
 sqlite3 var/app.db ".tables"
 sqlite3 var/app.db "SELECT id, role, tg_id FROM users;"
+
+## EPIC-2: StateStore & Callback demo
+В боте есть демо:
+```
+/demo  # покажет кнопку, payload хранится в state_store на 60с
+```
+Нажатие на кнопку извлечёт payload и удалит ключ (destroy-on-read).

--- a/app/bot/demo_epic2.py
+++ b/app/bot/demo_epic2.py
@@ -1,0 +1,29 @@
+from aiogram import F, Router, types
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
+
+from app.core import callbacks
+
+router = Router()
+
+
+@router.message()
+async def demo_help(msg: types.Message):
+    if msg.text != "/demo":
+        return
+    data = {"hello": "world", "by": "epic2"}
+    cb = callbacks.build(op="DEMO", value=data, role=None, ttl_sec=60)
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Жми меня (EPIC-2)", callback_data=cb)]
+        ]
+    )
+    await msg.answer(
+        "Демо EPIC-2: кнопка хранит payload в state_store на 60с", reply_markup=kb
+    )
+
+
+@router.callback_query(F.data.startswith("DEMO:"))
+async def on_demo(cbq: CallbackQuery):
+    op, payload = callbacks.extract(cbq.data, expected_role=None)
+    await cbq.message.edit_text(f"Callback {op} ок, payload: {payload}")
+    await cbq.answer("OK")

--- a/app/bot/main.py
+++ b/app/bot/main.py
@@ -18,6 +18,10 @@ async def main():
     bot = Bot(cfg.telegram_token)
     dp = Dispatcher()
     dp.message.register(on_start, CommandStart())
+    # EPIC-2 demo router
+    from app.bot.demo_epic2 import router as demo_router
+
+    dp.include_router(demo_router)
     await dp.start_polling(bot)
 
 

--- a/app/core/callbacks.py
+++ b/app/core/callbacks.py
@@ -1,0 +1,36 @@
+from typing import Any, Optional, Tuple
+
+from app.core import state_store
+from app.core.errors import StateError
+
+SEPARATOR = ":"
+
+
+def build(
+    op: str,
+    value: Any,
+    role: Optional[str] = None,
+    ttl_sec: int = state_store.DEFAULT_TTL_SEC,
+) -> str:
+    """Create callback data: f"{op}:{key}" and store value in state_store."""
+    assert SEPARATOR not in op, "op must not contain ':'"
+    key = state_store.put(value=value, role=role, ttl_sec=ttl_sec)
+    return f"{op}{SEPARATOR}{key}"
+
+
+def parse(data: str) -> Tuple[str, str]:
+    if SEPARATOR not in data:
+        return data, ""
+    op, key = data.split(SEPARATOR, 1)
+    return op, key
+
+
+def extract(data: str, expected_role: Optional[str] = None) -> Tuple[str, Any]:
+    """Parse callback data, fetch value from state_store, return (op, value)."""
+    op, key = parse(data)
+    if not key:
+        raise StateError("no state key in callback data")
+    value = state_store.get(key, expected_role=expected_role)
+    # destroy-on-read to avoid replay
+    state_store.delete(key)
+    return op, value

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -1,0 +1,14 @@
+class StateError(Exception):
+    code = "E_STATE"
+
+
+class StateNotFound(StateError):
+    code = "E_STATE_NOT_FOUND"
+
+
+class StateExpired(StateError):
+    code = "E_STATE_EXPIRED"
+
+
+class StateRoleMismatch(StateError):
+    code = "E_STATE_ROLE_MISMATCH"

--- a/app/core/state_store.py
+++ b/app/core/state_store.py
@@ -1,0 +1,77 @@
+import json
+import time
+import uuid
+from typing import Any, Optional
+
+from app.core.errors import StateExpired, StateNotFound, StateRoleMismatch
+from app.db.conn import db
+
+DEFAULT_TTL_SEC = 15 * 60  # 15 minutes
+
+
+def now() -> int:
+    return int(time.time())
+
+
+def _ensure_table():
+    # Table is created by migrations; keep as guard in dev
+    with db() as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS state_store ("
+            "key TEXT PRIMARY KEY, role TEXT, value_json TEXT NOT NULL, "
+            "created_at_utc INTEGER NOT NULL, expires_at_utc INTEGER NOT NULL)"
+        )
+
+
+def gen_key() -> str:
+    # Short key: first 12 chars of uuid4
+    return uuid.uuid4().hex[:12]
+
+
+def put(value: Any, role: Optional[str] = None, ttl_sec: int = DEFAULT_TTL_SEC) -> str:
+    """Store value with optional role restriction. Returns a generated key."""
+    _ensure_table()
+    k = gen_key()
+    created = now()
+    expires = created + max(1, ttl_sec)
+    payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    with db() as conn:
+        conn.execute(
+            "INSERT INTO state_store(key, role, value_json, created_at_utc, expires_at_utc) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (k, role, payload, created, expires),
+        )
+        conn.commit()
+    return k
+
+
+def get(key: str, expected_role: Optional[str] = None) -> Any:
+    _ensure_table()
+    with db() as conn:
+        row = conn.execute(
+            "SELECT role, value_json, expires_at_utc FROM state_store WHERE key = ?",
+            (key,),
+        ).fetchone()
+    if row is None:
+        raise StateNotFound("state key not found")
+    role, value_json, expires = row["role"], row["value_json"], row["expires_at_utc"]
+    if expires < now():
+        delete(key)
+        raise StateExpired("state key expired")
+    if expected_role and role and expected_role != role:
+        raise StateRoleMismatch(f"expected role {expected_role}, got {role}")
+    return json.loads(value_json)
+
+
+def delete(key: str) -> None:
+    with db() as conn:
+        conn.execute("DELETE FROM state_store WHERE key = ?", (key,))
+        conn.commit()
+
+
+def cleanup_expired() -> int:
+    """Delete expired records. Returns number of rows removed."""
+    with db() as conn:
+        cur = conn.execute("DELETE FROM state_store WHERE expires_at_utc < ?", (now(),))
+        conn.commit()
+        return cur.rowcount

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,11 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.flake8]
 max-line-length = 120
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["app"]

--- a/scripts/cleanup_state.py
+++ b/scripts/cleanup_state.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+from app.core.state_store import cleanup_expired
+
+n = cleanup_expired()
+print(f"[state-store] cleaned {n} expired entries")

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,35 @@
+import time
+
+from app.core import state_store
+from app.core.errors import StateExpired, StateNotFound, StateRoleMismatch
+
+
+def test_put_get_delete_roundtrip():
+    key = state_store.put({"x": 1}, role="owner", ttl_sec=5)
+    val = state_store.get(key, expected_role="owner")
+    assert val == {"x": 1}
+    state_store.delete(key)
+    try:
+        state_store.get(key)
+        assert False, "should not reach"
+    except StateNotFound:
+        pass
+
+
+def test_expiry():
+    key = state_store.put({"y": 2}, role=None, ttl_sec=1)
+    time.sleep(2.1)
+    try:
+        state_store.get(key)
+        assert False, "expected expired"
+    except StateExpired:
+        pass
+
+
+def test_role_mismatch():
+    key = state_store.put({"z": 3}, role="teacher", ttl_sec=5)
+    try:
+        state_store.get(key, expected_role="student")
+        assert False, "expected role mismatch"
+    except StateRoleMismatch:
+        pass


### PR DESCRIPTION
### EPIC-2: StateStore & Callback codec

- Добавлен сервис `state_store` (put/get/delete/cleanup).
- Реализованы ошибки (`StateNotFound`, `StateExpired`, `StateRoleMismatch`).
- Добавлен кодек для callback-данных (`build`, `extract`).
- Написаны юнит-тесты для StateStore.
- Скрипт очистки просроченных ключей + цель `make state-clean`.
- Демо `/demo` в боте: кнопка хранит payload в StateStore, при нажатии восстанавливается и удаляется.

✅ Проверено локально:
- Тесты зелёные.
- `/demo` работает, state-clean чистит протухшие ключи.

---

➡️ Далее: **EPIC-3 — Users & Roles (аутентификация + имперсонизация)**.
