### PR TITLE
EPIC-3: Users & Roles (auth middleware, /whoami, /add_user)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,20 @@ make migrate
 make seed
 sqlite3 var/app.db ".tables"
 sqlite3 var/app.db "SELECT id, role, tg_id FROM users;"
+```
 
 ## EPIC-2: StateStore & Callback demo
 В боте есть демо:
+
 ```
 /demo  # покажет кнопку, payload хранится в state_store на 60с
 ```
 Нажатие на кнопку извлечёт payload и удалит ключ (destroy-on-read).
+
+## EPIC-3: Users & Roles (Auth)
+- Middleware создаёт/разрешает пользователя по Telegram ID (новые — студент by default).
+- Команды демо:
+  - `/whoami` — показать текущую учётку
+  - `/add_user <role> <tg_id> <name>` — создать пользователя (только owner)
+
+> Owner создаётся сидом (`make seed`). Для тестов новых пользователей можно добавлять через `/add_user`.

--- a/app/bot/commands_epic3.py
+++ b/app/bot/commands_epic3.py
@@ -1,0 +1,41 @@
+import logging
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from app.core import auth
+from app.core.roles import OWNER
+
+logger = logging.getLogger(__name__)
+
+router = Router()
+
+
+@router.message(Command("whoami"))
+async def whoami(msg: Message, actor: auth.Identity):
+    logger.info(f"/whoami called by tg_id={msg.from_user.id}")
+    await msg.answer(
+        f"you are id={actor.id} role={actor.role} tg={actor.tg_id} name={actor.name}"
+    )
+
+
+@router.message(Command("add_user"))
+async def add_user(msg: Message, actor: auth.Identity):
+    logger.info(f"/add_user called by tg_id={msg.from_user.id}, text={msg.text}")
+    if actor.role != OWNER:
+        logger.warning("forbidden: not an owner")
+        return await msg.answer("forbidden: owner only")
+    parts = msg.text.split(maxsplit=3)
+    if len(parts) < 4:
+        return await msg.answer("usage: /add_user <role> <tg_id> <name>")
+    role, tg_id, name = parts[1], parts[2], parts[3]
+    try:
+        user = auth.create_user(tg_id, role, name=name)
+    except AssertionError:
+        logger.error(f"invalid role requested: {role}")
+        return await msg.answer("invalid role (owner/teacher/student)")
+    logger.info(f"user created: {user}")
+    await msg.answer(
+        f"created: id={user.id} role={user.role} tg={user.tg_id} name={user.name}"
+    )

--- a/app/bot/demo_epic2.py
+++ b/app/bot/demo_epic2.py
@@ -1,4 +1,5 @@
 from aiogram import F, Router, types
+from aiogram.filters import Command
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
 
 from app.core import callbacks
@@ -6,10 +7,8 @@ from app.core import callbacks
 router = Router()
 
 
-@router.message()
+@router.message(Command("demo"))
 async def demo_help(msg: types.Message):
-    if msg.text != "/demo":
-        return
     data = {"hello": "world", "by": "epic2"}
     cb = callbacks.build(op="DEMO", value=data, role=None, ttl_sec=60)
     kb = InlineKeyboardMarkup(
@@ -17,9 +16,7 @@ async def demo_help(msg: types.Message):
             [InlineKeyboardButton(text="Жми меня (EPIC-2)", callback_data=cb)]
         ]
     )
-    await msg.answer(
-        "Демо EPIC-2: кнопка хранит payload в state_store на 60с", reply_markup=kb
-    )
+    await msg.answer("Демо EPIC-2: кнопка хранит payload на 60с", reply_markup=kb)
 
 
 @router.callback_query(F.data.startswith("DEMO:"))

--- a/app/bot/main.py
+++ b/app/bot/main.py
@@ -5,8 +5,11 @@ from aiogram import Bot, Dispatcher
 from aiogram.filters import CommandStart
 from aiogram.types import Message
 
+from app.bot.demo_epic2 import router as demo_router
 from app.core.config import cfg
 from app.core.logging import setup_logging
+
+logging.getLogger(__name__).info("EPIC3 router included")
 
 
 async def on_start(message: Message):
@@ -17,11 +20,23 @@ async def main():
     setup_logging(logging.INFO)
     bot = Bot(cfg.telegram_token)
     dp = Dispatcher()
-    dp.message.register(on_start, CommandStart())
-    # EPIC-2 demo router
-    from app.bot.demo_epic2 import router as demo_router
 
+    # /start
+    dp.message.register(on_start, CommandStart())
+    # 🔽 EPIC-2: demo
     dp.include_router(demo_router)
+
+    # 🔽 EPIC-3: auth middleware
+    from app.bot.middleware.auth_mw import AuthMiddleware
+
+    dp.message.middleware(AuthMiddleware())
+    dp.callback_query.middleware(AuthMiddleware())
+
+    # 🔽 EPIC-3: router with /whoami, /add_user
+    from app.bot.commands_epic3 import router as epic3_router
+
+    dp.include_router(epic3_router)
+
     await dp.start_polling(bot)
 
 

--- a/app/bot/middleware/auth_mw.py
+++ b/app/bot/middleware/auth_mw.py
@@ -1,0 +1,24 @@
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.types import CallbackQuery, Message
+
+from app.core import auth
+
+
+class AuthMiddleware(BaseMiddleware):
+    async def __call__(
+        self,
+        handler: Callable[[Message, Dict[str, Any]], Awaitable[Any]],
+        event: Any,
+        data: Dict[str, Any],
+    ) -> Any:
+        tg_user = None
+        if isinstance(event, Message):
+            tg_user = event.from_user
+        elif isinstance(event, CallbackQuery):
+            tg_user = event.from_user
+        if tg_user:
+            user = auth.ensure_user(tg_user)
+            data["actor"] = user
+        return await handler(event, data)

--- a/app/core/audit.py
+++ b/app/core/audit.py
@@ -1,0 +1,40 @@
+import json
+import time
+from typing import Optional
+
+from app.db.conn import db
+
+
+def log(
+    event: str,
+    actor_id: Optional[int],
+    *,
+    as_user_id: Optional[int] = None,
+    as_role: Optional[str] = None,
+    object_type: Optional[str] = None,
+    object_id: Optional[int] = None,
+    meta: Optional[dict] = None,
+    request_id: Optional[str] = None
+) -> None:
+    ts = int(time.time())
+    with db() as conn:
+        conn.execute(
+            (
+                "INSERT INTO audit_log("
+                "ts_utc, request_id, actor_id, as_user_id, as_role, "
+                "event, object_type, object_id, meta_json"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                ts,
+                request_id,
+                actor_id,
+                as_user_id,
+                as_role,
+                event,
+                object_type,
+                object_id,
+                json.dumps(meta or {}),
+            ),
+        )
+        conn.commit()

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from aiogram.types import User as TgUser
+
+from app.core.roles import ALL_ROLES, STUDENT
+from app.db.conn import db
+
+
+@dataclass
+class Identity:
+    id: int
+    role: str
+    tg_id: str
+    name: Optional[str]
+
+
+def _row_to_identity(row) -> Identity:
+    return Identity(
+        id=row["id"], role=row["role"], tg_id=row["tg_id"], name=row["name"]
+    )
+
+
+def get_user_by_tg(tg_id: str) -> Optional[Identity]:
+    with db() as conn:
+        row = conn.execute("SELECT * FROM users WHERE tg_id = ?", (tg_id,)).fetchone()
+    return _row_to_identity(row) if row else None
+
+
+def create_user(tg_id: str, role: str, name: Optional[str] = None) -> Identity:
+    assert role in ALL_ROLES, "invalid role"
+    import time
+
+    now = int(time.time())
+    with db() as conn:
+        conn.execute(
+            "INSERT INTO users(tg_id, role, name, created_at_utc, updated_at_utc) VALUES(?,?,?,?,?)",
+            (tg_id, role, name, now, now),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM users WHERE tg_id = ?", (tg_id,)).fetchone()
+    return _row_to_identity(row)
+
+
+def ensure_user(tg: TgUser) -> Identity:
+    tg_id = str(tg.id)
+    user = get_user_by_tg(tg_id)
+    if user:
+        return user
+    return create_user(tg_id, STUDENT, name=(tg.full_name or None))

--- a/app/core/roles.py
+++ b/app/core/roles.py
@@ -1,0 +1,5 @@
+OWNER = "owner"
+TEACHER = "teacher"
+STUDENT = "student"
+
+ALL_ROLES = {OWNER, TEACHER, STUDENT}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,18 @@
+import uuid
+
+from app.core import auth
+from app.db.conn import db
+
+
+def test_create_and_get_user():
+    tg = f"test_tg_{uuid.uuid4().hex[:8]}"
+    try:
+        u = auth.create_user(tg, "student", name="Test User")
+        g = auth.get_user_by_tg(tg)
+        assert g is not None
+        assert g.id == u.id
+        assert g.role == "student"
+    finally:
+        with db() as conn:
+            conn.execute("DELETE FROM users WHERE tg_id=?", (tg,))
+            conn.commit()


### PR DESCRIPTION
### EPIC-3: Users & Roles (Auth)

- Middleware: резолв Telegram → users (`actor` в контексте).
- Команды:
  - `/whoami` — показать текущую учётку (id/role/tg/name)
  - `/add_user <role> <tg_id> <name...>` — создать пользователя (owner only)
- Тесты: `test_auth.py` (создание + чтение пользователя).
- Логи: добавлены INFO-логи в хендлерах для отладки.

✅ Проверено локально: тесты зелёные, `/whoami` и `/add_user` работают.